### PR TITLE
feat: add route for tags

### DIFF
--- a/.changeset/three-drinks-explain.md
+++ b/.changeset/three-drinks-explain.md
@@ -1,0 +1,5 @@
+---
+'halprin-web-app': minor
+---
+
+Add example of tag route by slugs

--- a/apps/halprin-web-app/src/pages/tags/[tagSlugs].tsx
+++ b/apps/halprin-web-app/src/pages/tags/[tagSlugs].tsx
@@ -1,0 +1,50 @@
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { BadRequest } from '@tsed/exceptions';
+import { videoConfig } from '@/features/video/video.config';
+import { SupportedLang } from '@/features/video/types';
+import { SiteConfigUtils } from '@/core/config/site- config.utils';
+import { Asserts } from '@contredanse/common';
+
+type Props = {
+  tagSlugs: string[];
+  lang: SupportedLang;
+};
+
+export default function TagsRoute(
+  props: InferGetServerSidePropsType<typeof getServerSideProps>
+) {
+  const { lang, tagSlugs } = props;
+  return (
+    <>
+      <h1>Hello here's the tag slugs I received</h1>
+      <pre>{JSON.stringify(tagSlugs)}</pre>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  const { locale } = context;
+  if (locale === undefined || !SiteConfigUtils.isSupportedLocale(locale)) {
+    throw new BadRequest('locale is missing or not supported');
+  }
+  const { tagSlugs } = context.params ?? {};
+
+  Asserts.nonEmptyString(tagSlugs, () => {
+    throw new BadRequest('tagSlugs must be a non empty string');
+  });
+
+  const slugs = tagSlugs.split(':').filter((tag) => tag.trim() !== '');
+
+  const { i18nNamespaces } = videoConfig;
+  return {
+    props: {
+      tagSlugs: slugs,
+      lang: locale,
+      // @see https:/github.com/i18next/react-i18next/pull/1340#issuecomment-874728587
+      ...(await serverSideTranslations(locale, i18nNamespaces.slice())),
+    },
+  };
+};


### PR DESCRIPTION
@Nils-Lopez this is how we can do a route in NextJS based on a tag

http://localhost:3000/tags/tag-1:tag-2

I'll add another 2 examples for the videos. But I'm not sure what you exactly want to do for it. And It's difficult to have you in chat and whats app for tasks won't help.

It's better for me that you send me what route you want ?, i.e:

```
/path/[slug or params]
```

I've opened a second P/R https://github.com/contredanse/life-art/pull/100 with an example based on videos. 

Choose  the one you prefer

